### PR TITLE
Ignore existing query params when URL encoding image name

### DIFF
--- a/tachyon.php
+++ b/tachyon.php
@@ -40,7 +40,7 @@ function tachyon_url( $image_url, $args = array(), $scheme = null ) {
 
 	$image_url = trim( $image_url );
 
-	$image_file = basename( $image_url );
+	$image_file = basename( parse_url( $image_url, PHP_URL_PATH ) );
 	$image_url  = str_replace( $image_file, urlencode( $image_file ), $image_url );
 
 	if ( strpos( $image_url, $upload_dir['baseurl'] ) !== 0 ) {


### PR DESCRIPTION
Noticed issue on local with gallery image srcset URLs, my bad.

cc @joehoyle