### PR TITLE
Update reference to Photon source code.

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -7,7 +7,7 @@ class Tachyon {
 	// Oh look, a singleton
 	private static $__instance = null;
 
-	// Allowed extensions must match http://code.trac.wordpress.org/browser/tachyon/index.php#L31
+	// Allowed extensions must match https://code.trac.wordpress.org/browser/photon/index.php#L33
 	protected static $extensions = array(
 		'gif',
 		'jpg',


### PR DESCRIPTION
Since https://code.trac.wordpress.org/browser/tachyon/ returns an error, I believe this commit adds the correct URL.

<img width="621" alt="screen shot 2017-11-05 at 4 09 08 pm" src="https://user-images.githubusercontent.com/45068/32419157-b4eddfb6-c243-11e7-86ce-39ad36226c89.png">
