### PR TITLE
Return original image size when crop is larger than original.

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -532,8 +532,15 @@ class Tachyon {
 
 				$image_meta = wp_get_attachment_metadata( $attachment_id );
 				$image_resized = image_resize_dimensions( $image_meta['width'], $image_meta['height'], $width, $height );
-				$width = $image_resized[6];
-				$height = $image_resized[7];
+				if ( $image_resized ) {
+					// Use the resized image dimensions.
+					$width = $image_resized[6];
+					$height = $image_resized[7];
+				} else {
+					// Resized image would be larger than original.
+					$width = $image_meta['width'];
+					$height = $image_meta['height'];
+				}
 
 				list( $width, $height ) = image_constrain_size_for_editor( $width, $height, $size );
 


### PR DESCRIPTION
The WP core function `image_resize_dimensions()` returns `false` when a requested crop is larger than the original image.

When this happens, Tachyon should return an image of the original size.

Fixes #24.