### PR TITLE
Add support for the medium_large image size

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -743,6 +743,11 @@ class Tachyon {
 					'height' => intval( get_option( 'medium_size_h' ) ),
 					'crop'   => false
 				),
+				'medium_large' => array(
+					'width'  => intval( get_option( 'medium_large_size_w' ) ),
+					'height' => intval( get_option( 'medium_large_size_h' ) ),
+					'crop'   => false
+				),
 				'large'  => array(
 					'width'  => intval( get_option( 'large_size_w' ) ),
 					'height' => intval( get_option( 'large_size_h' ) ),


### PR DESCRIPTION
A new built in image size was added in WP some time ago, `medium_large`. This updates the tachyon plugin to process it properly.