### PR TITLE
WIP Filter attachment meta data for Tachyon.

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -690,6 +690,8 @@ class Tachyon {
 		$mime_type = get_post_mime_type( $attachment_id );
 		$filename = pathinfo( $data['file'], PATHINFO_FILENAME );
 		$ext = pathinfo( $data['file'], PATHINFO_EXTENSION );
+		$orig_w = $data['width'];
+		$orig_h = $data['height'];
 
 		foreach ( $image_sizes as $size => $crop ) {
 			if ( isset( $data['sizes'][ $size ] ) ) {
@@ -702,11 +704,21 @@ class Tachyon {
 				continue;
 			}
 
+			$new_dims = image_resize_dimensions( $orig_w, $orig_h, $crop['width'], $crop['height'], $crop['crop'] );
+
+			if ( ! $new_dims ) {
+				continue;
+			}
+
+			$w = (int) $new_dims[6];
+			$h = (int) $new_dims[7];
+
+
 			// Add meta data with fake WP style file name.
 			$data['sizes'][ $size ] = array(
-				'width' => (int) $crop['width'],
-				'height' => (int) $crop['height'],
-				'file' => "{$filename}-{$crop['width']}x{$crop['height']}.{$ext}",
+				'width' => $w,
+				'height' => $h,
+				'file' => "{$filename}-{$w}x{$h}.{$ext}",
 				'mime-type' => $mime_type,
 			);
 		}


### PR DESCRIPTION
**Note:** I'm unsure how Tachyon works out the crop gravity on the srcset so I've ignored the problem. 

This fixes two issues.

In Tachyon, image sizes created after upload are not included in the `srcset` as they are not included in the image meta data stored by WordPress.

In `wp_calculate_image_srcset()` WordPress does not run the srcset filter if the `wp_get_attachment_metadata()` does not include resized images. For users of Tachyon who disable resize on upload, no resized images exist.
