### PR TITLE
Fix pass by ref warning

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -245,7 +245,8 @@ class Tachyon {
 									if ( $meta['sizes'] ) {
 										$sizes = wp_list_filter( $meta['sizes'], [ 'file' => basename( $src ) ] );
 										if ( $sizes ) {
-											$size = array_pop( array_keys( $sizes ) );
+											$size_names = array_keys( $sizes );
+											$size = array_pop( $size_names );
 										}
 									}
 								}


### PR DESCRIPTION
Noticed this warning being thrown:

> PHP Notice: Only variables should be passed by reference in .../tachyon-plugin/inc/class-tachyon.php on line 248

🔥`array_pop()`