### PR TITLE
Use wp_constrain_dimensions to calculate size

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -545,6 +545,10 @@ class Tachyon {
 						// Lets make sure that we don't upscale images since wp never upscales them as well
 						$smaller_width  = ( ( $image_meta['width']  < $image_args['width']  ) ? $image_meta['width']  : $image_args['width']  );
 						$smaller_height = ( ( $image_meta['height'] < $image_args['height'] ) ? $image_meta['height'] : $image_args['height'] );
+						
+						// Reset $image_meta dimensions to resized values.
+						$image_meta['width']  = $smaller_width;
+						$image_meta['height'] = $smaller_height;
 
 						$tachyon_args[ $transform ] = $smaller_width . ',' . $smaller_height;
 						$is_intermediate = true;
@@ -584,26 +588,14 @@ class Tachyon {
 				 */
 				$tachyon_args = apply_filters( 'tachyon_image_downsize_string', $tachyon_args, compact( 'image_args', 'image_url', 'attachment_id', 'size', 'transform' ) );
 
-				// Calculate the correct target width & height.
+				// Generate Tachyon URL.
 				// We want the width / height params to match the dimensions of the image,
 				// not the resize dimensions. The Resize dimensions might be "Max width" /
 				// "Max-height" dimensions, rather than absolute image size.
-				$target_width  = $image_args['width'];
-				$target_height = $image_args['height'];
-				if ( ! $image_args['crop'] ) {
-					list( $target_width, $target_height ) = wp_constrain_dimensions(
-						$image_meta['width'],
-						$image_meta['height'],
-						$image_args['width'],
-						$image_args['height']
-					);
-				}
-
-				// Generate Tachyon URL.
 				$image = array(
 					tachyon_url( $image_url, $tachyon_args ),
-					$target_width,
-					$target_height,
+					isset( $image_meta['width'] ) ? $image_meta['width'] : $image_args['width'],
+					isset( $image_meta['height'] ) ? $image_meta['height'] : $image_args['height'],
 					$is_intermediate,
 				);
 			} elseif ( is_array( $size ) ) {

--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -584,14 +584,26 @@ class Tachyon {
 				 */
 				$tachyon_args = apply_filters( 'tachyon_image_downsize_string', $tachyon_args, compact( 'image_args', 'image_url', 'attachment_id', 'size', 'transform' ) );
 
-				// Generate Tachyon URL.
+				// Calculate the correct target width & height.
 				// We want the width / height params to match the dimensions of the image,
 				// not the resize dimensions. The Resize dimensions might be "Max width" /
 				// "Max-height" dimensions, rather than absolute image size.
+				$target_width  = $image_args['width'];
+				$target_height = $image_args['height'];
+				if ( ! $image_args['crop'] ) {
+					list( $target_width, $target_height ) = wp_constrain_dimensions(
+						$image_meta['width'],
+						$image_meta['height'],
+						$image_args['width'],
+						$image_args['height']
+					);
+				}
+
+				// Generate Tachyon URL.
 				$image = array(
 					tachyon_url( $image_url, $tachyon_args ),
-					isset( $image_meta['width'] ) ? $image_meta['width'] : $image_args['width'],
-					isset( $image_meta['height'] ) ? $image_meta['height'] : $image_args['height'],
+					$target_width,
+					$target_height,
 					$is_intermediate,
 				);
 			} elseif ( is_array( $size ) ) {


### PR DESCRIPTION
This returns the real image size in pixels for the downsized image rather than falling back to the original image dimensions.

Fixes #41 