### PR TITLE
Fix reported size dimensions in downsize filter

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -547,7 +547,7 @@ class Tachyon {
 				$image_meta = image_get_intermediate_size( $attachment_id, $size );
 
 				// 'full' is a special case: We need consistent data regardless of the requested size.
-				if ( 'full' == $size ) {
+				if ( 'full' === $size ) {
 					$image_meta = $full_size_meta;
 				} elseif ( ! $image_meta ) {
 					// If we still don't have any image meta at this point, it's probably from a custom thumbnail size
@@ -565,6 +565,9 @@ class Tachyon {
 					$is_intermediate = true;
 				}
 
+				// Expose determined arguments to a filter before passing to Tachyon
+				$transform = $image_args['crop'] ? 'resize' : 'fit';
+
 				// If we can't get the width from the image size args, use the width of the
 				// image metadata. We only do this is image_args['width'] is not set, because
 				// we don't want to lose this data. $image_args is used as the Tachyon URL param
@@ -572,33 +575,40 @@ class Tachyon {
 				// size is 300x300px, non-cropped, we want to pass `fit=300,300` to Tachyon, instead
 				// of say `resize=300,225`, because semantically, the image size is registered as
 				// 300x300 un-cropped, not 300x225 cropped.
-				if ( empty( $image_args['width'] ) ) {
+				if ( empty( $image_args['width'] ) && $transform !== 'resize' ) {
 					$image_args['width'] = isset( $image_meta['width'] ) ? $image_meta['width'] : 0;
 				}
 
-				if ( empty( $image_args['height'] ) ) {
+				if ( empty( $image_args['height'] ) && $transform !== 'resize' ) {
 					$image_args['height'] = isset( $image_meta['height'] ) ? $image_meta['height'] : 0;
 				}
 
-				list( $image_args['width'], $image_args['height'] ) = image_constrain_size_for_editor( $image_args['width'], $image_args['height'], $size, 'display' );
+				// Prevent upscaling.
+				$image_args['width'] = min( (int) $image_args['width'], (int) $full_size_meta['width'] );
+				$image_args['height'] = min( (int) $image_args['height'], (int) $full_size_meta['height'] );
 
-				// Expose determined arguments to a filter before passing to Tachyon
-				$transform = $image_args['crop'] ? 'resize' : 'fit';
+				// Respect $content_width settings.
+				list( $width, $height ) = image_constrain_size_for_editor( $image_meta['width'], $image_meta['height'], $size, 'display' );
 
 				// Check specified image dimensions and account for possible zero values; tachyon fails to resize if a dimension is zero.
-				if ( 0 == $image_args['width'] || 0 == $image_args['height'] ) {
+				if ( ( 0 == $image_args['width'] || 0 == $image_args['height'] ) && $transform !== 'fit' ) {
 					if ( 0 == $image_args['width'] && 0 < $image_args['height'] ) {
 						$tachyon_args['h'] = $image_args['height'];
 					} elseif ( 0 == $image_args['height'] && 0 < $image_args['width'] ) {
 						$tachyon_args['w'] = $image_args['width'];
 					}
 				} else {
-					if ( 'resize' === $transform || ! $image_meta ) {
-						$image_meta = $full_size_meta;
+
+					// if fit
+					// image args should be as original size definition restricted by max size
+
+					// If resizing:
+					// Both width & height required, image args should be exact dimensions.
+					if ( $transform === 'resize' ) {
+						$image_args['width'] = $image_args['width'] ?: $width;
+						$image_args['height'] = $image_args['height'] ?: $height;
 					}
 
-					$image_args['width'] = min( (int) $image_args['width'], (int) $image_meta['width'] );
-					$image_args['height'] = min( (int) $image_args['height'], (int) $image_meta['height'] );
 					$is_intermediate = ( $image_args['width'] < $full_size_meta['width'] || $image_args['height'] < $full_size_meta['height'] );
 
 					// Add transform args if size is intermediate.
@@ -641,8 +651,8 @@ class Tachyon {
 				// Generate Tachyon URL.
 				$image = array(
 					tachyon_url( $image_url, $tachyon_args ),
-					! empty( $image_args['width'] ) ? $image_args['width'] : false,
-					! empty( $image_args['height'] ) ? $image_args['height'] : false,
+					$width,
+					$height,
 					$is_intermediate,
 				);
 			} elseif ( is_array( $size ) ) {

--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -598,12 +598,9 @@ class Tachyon {
 						$tachyon_args['w'] = $image_args['width'];
 					}
 				} else {
-
-					// if fit
-					// image args should be as original size definition restricted by max size
-
+					// Fit accepts a zero value for either dimension so we allow that.
 					// If resizing:
-					// Both width & height required, image args should be exact dimensions.
+					// Both width & height are required, image args should be exact dimensions.
 					if ( $transform === 'resize' ) {
 						$image_args['width'] = $image_args['width'] ?: $width;
 						$image_args['height'] = $image_args['height'] ?: $height;

--- a/tests/tests/class-resizing.php
+++ b/tests/tests/class-resizing.php
@@ -190,6 +190,7 @@ class Tests_Resizing extends WP_UnitTestCase {
 				'large',
 				[
 					'http://tachy.on/u/tachyon.jpg?fit=1024,575',
+					'http://tachy.on/u/tachyon.jpg?fit=1024,719',
 					'http://tachy.on/u/tachyon.jpg?resize=1024,575',
 					'http://tachy.on/u/tachyon.jpg?fit=1024,1024',
 					'http://tachy.on/u/tachyon.jpg?w=1024&h=575',
@@ -349,7 +350,6 @@ class Tests_Resizing extends WP_UnitTestCase {
 				'large',
 				[
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,576',
-					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,719',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?resize=1024,576',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,1024',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?w=1024&h=576',

--- a/tests/tests/class-resizing.php
+++ b/tests/tests/class-resizing.php
@@ -349,6 +349,7 @@ class Tests_Resizing extends WP_UnitTestCase {
 				'large',
 				[
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,576',
+					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,719',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?resize=1024,576',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=1024,1024',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?w=1024&h=576',
@@ -371,6 +372,7 @@ class Tests_Resizing extends WP_UnitTestCase {
 				'tachyon-large',
 				'oversize2d-early',
 				[
+					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=2500,1440',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=2500,1406',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?resize=2500,1406',
 					'http://tachy.on/u/tachyon-large-scaled.jpg?fit=2500,1500',


### PR DESCRIPTION
After #50 we had an issue where the image dimensions returned by the downsize filter could be incorrect due to picking the smallest value between `$image_meta` and the `$image_args`, this meant the aspect ratio could get out of sync.