### PR TITLE
Ensure attachment meta contains width/height before resizing

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -706,16 +706,18 @@ class Tachyon {
 				}
 
 				$image_meta = wp_get_attachment_metadata( $attachment_id );
-				$image_resized = image_resize_dimensions( $image_meta['width'], $image_meta['height'], $width, $height );
-				if ( $image_resized ) {
-					// Use the resized image dimensions.
-					$width = $image_resized[6];
-					$height = $image_resized[7];
-					$is_intermediate = true;
-				} else {
-					// Resized image would be larger than original.
-					$width = $image_meta['width'];
-					$height = $image_meta['height'];
+				if ( isset( $image_meta['width'] ) && isset( $image_meta['height'] ) ) {
+					$image_resized = image_resize_dimensions( $image_meta['width'], $image_meta['height'], $width, $height );
+					if ( $image_resized ) {
+						// Use the resized image dimensions.
+						$width = $image_resized[6];
+						$height = $image_resized[7];
+						$is_intermediate = true;
+					} else {
+						// Resized image would be larger than original.
+						$width = $image_meta['width'];
+						$height = $image_meta['height'];
+					}
 				}
 
 				list( $width, $height ) = image_constrain_size_for_editor( $width, $height, $size );


### PR DESCRIPTION
It's possible for `wp_get_attachment_metadata` to return false, or to return a metadata object which doesn't have width and height properties defined. In those cases, this code would previously have thrown a series of warnings.

```
PHP Warning:  Illegal string offset 'width' in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 667
PHP Warning:  Illegal string offset 'height' in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 667 
PHP Warning:  Illegal string offset 'width' in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 675
PHP Warning:  Illegal string offset 'height' in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 676
```

This PR adds some defensive coding to prevent triggering these warnings, in a similar way to how attachment meta is dealt with elsewhere in this file.

I believe this should also address #60. 