### PR TITLE
Handle missing metadata

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -582,7 +582,7 @@ class Tachyon {
 			}
 
 			// If an image is requested with a size known to WordPress, use that size's settings with Tachyon.
-			if ( ( is_string( $size ) || is_int( $size ) ) && array_key_exists( $size, self::image_sizes() ) ) {
+			if ( ! empty( $full_size_meta ) && ( is_string( $size ) || is_int( $size ) ) && array_key_exists( $size, self::image_sizes() ) ) {
 				$image_args = self::image_sizes();
 				$image_args = $image_args[ $size ];
 


### PR DESCRIPTION
In certain situations, especially with migrated legacy content, an image URL may be sent to tachyon for an image which doesn't exist on disk and may not have any stored metadata. In this case, because we never check that the meta array is well formed and didn't return as "false", several log warnings will be emitted:

```
Trying to access array offset on value of type bool | …achyon-plugin/inc/class-tachyon.php#631
Trying to access array offset on value of type bool | …achyon-plugin/inc/class-tachyon.php#632
```
(Observed in Altis 12 on PHP 8—it's very noisy.)

Almost all of our calculations in this `if` block assume that meta exists and ws returned as an array. If that's not true, we should move on to compute entirely based on the provided arguments.