### PR TITLE
Use Altis Docs link for function documentation

### DIFF
--- a/tachyon.php
+++ b/tachyon.php
@@ -25,7 +25,7 @@ Tachyon::instance();
 /**
  * Generates a Tachyon URL.
  *
- * @see http://developer.wordpress.com/docs/tachyon/
+ * @see https://docs.altis-dxp.com/media/dynamic-images/
  *
  * @param string $image_url URL to the publicly accessible image you want to manipulate.
  * @param array|string $args An array of arguments, i.e. array( 'w' => '300', 'resize' => array( 123, 456 ) ), or in string form (w=123&h=456).


### PR DESCRIPTION
The @see link in the `tachyon_url()` function returns a 404. I have updated the link to point to the Altis Documentation page on Dynamic Images, which documents using this function.