### PR TITLE
Fix attachment metadata failure warning

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -279,7 +279,7 @@ class Tachyon {
 								// to lookup the size for the image in the URL.
 								if ( ! isset( $size ) ) {
 									$meta = wp_get_attachment_metadata( $attachment_id );
-									if ( $meta['sizes'] ) {
+									if ( $meta && $meta['sizes'] ) {
 										$sizes = wp_list_filter( $meta['sizes'], [ 'file' => basename( $src ) ] );
 										if ( $sizes ) {
 											$size_names = array_keys( $sizes );


### PR DESCRIPTION
This handles the warning when attachment metadata is not available.

```
Warning: Trying to access array offset on value of type bool in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 282
Processed post 110591.
Warning: Trying to access array offset on value of type bool in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 282
Processed post 110590.
Warning: Trying to access array offset on value of type bool in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 282
Processed post 110589.
Warning: Trying to access array offset on value of type bool in /usr/src/app/vendor/humanmade/tachyon-plugin/inc/class-tachyon.php on line 282
Processed post 110588.
```