### PR TITLE
Retain S3 signed params in Tachyon srcset URLs

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -786,6 +786,19 @@ class Tachyon {
 			// It's quicker to get the full size with the data we have already, if available.
 			if ( isset( $image_meta['file'] ) ) {
 				$url = trailingslashit( $upload_dir['baseurl'] ) . $image_meta['file'];
+
+				// Retain AWS X-Amz signed requests params so they're passed through to Tachyon.
+				if ( str_contains( $source['url'], 'X-Amz-' ) ) {
+					$params = [];
+					$query = parse_url( $source['url'], PHP_URL_QUERY );
+					parse_str( $query, $params );
+
+					foreach ( $params as $key => $value ) {
+						if ( str_contains( $key, 'X-Amz-' ) ) {
+							$url = add_query_arg( $key, $value, $url );
+						}
+					}
+				}
 			} else {
 				$url = static::strip_image_dimensions_maybe( $url );
 			}


### PR DESCRIPTION

When `S3_UPLOADS_OBJECT_ACL` is defined to a private ACL like `authenticated-read` and S3 Uploads filter `s3_uploads_is_attachment_private` is set to `true` we observe Tachyon generating srcset URLs that don't contain the AWS signed params that would've been generated by S3 Uploads for the media files.

This looks to be a bug resulting from the `$url` that's sent to `tachyon_url()` function being created within the `filter_srcset_array()` function and losing those params from the source when `isset( $image_meta['file'] )` is `true`. If we have `isset( $image_meta['file'] )` as false, we don't notice the same bug because `static::strip_image_dimensions_maybe` only removes some query args and retains the rest which results in the signed params still being present in the generated srcset URLs for that case.

To test this, you can create a new site and set the above constant and filter then upload an image, select it in block editor via image block and preview the page. You'll observe the bug. Switching to this branch you should then observe the bug being fixed and the signed params existing in the srcset URLs generated by Tachyon.

Note local installs don't support S3 ACLs so you'll still be able to observe the image srcsets loading even with the absence of the signed params when the bug is observed.