### PR TITLE
Decode URLs when parsing them from content

### DIFF
--- a/inc/class-tachyon.php
+++ b/inc/class-tachyon.php
@@ -206,6 +206,9 @@ class Tachyon {
 					$src = $src_orig = $lazy_load_src[1];
 				}
 
+				// Image src coming from HTML is expected to be htmlentityencoded.
+				$src = html_entity_decode( $src );
+
 				// Check if image URL should be used with Tachyon.
 				if ( self::validate_image_url( $src ) ) {
 					// Find the width and height attributes.


### PR DESCRIPTION
WordPress stores URLs in the post content as html entity encoded. Thi means in cases when there are images in the content that have query params, currently our replacements around the use of `presign` break. In all other cases `tachyon_url()` expects a clean URL, not a htmlentities applied one, so we make sure to be consistent.
